### PR TITLE
Improve ergonomics of types

### DIFF
--- a/openai-servant/src/OpenAI/Resources.hs
+++ b/openai-servant/src/OpenAI/Resources.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module OpenAI.Resources
   ( -- * Core Types
@@ -56,6 +57,7 @@ import Data.String (IsString(..))
 import Data.Time
 import Data.Time.Clock.POSIX
 import qualified Data.Vector as V
+import GHC.Exts (IsList)
 import OpenAI.Internal.Aeson
 import Servant.API
 import Servant.Multipart.API
@@ -83,6 +85,7 @@ newtype OpenAIList a = OpenAIList
   { olData :: V.Vector a
   }
   deriving stock (Show, Eq, Functor)
+  deriving newtype (IsList)
 
 instance Semigroup (OpenAIList a) where
   (<>) a b = OpenAIList (olData a <> olData b)
@@ -291,10 +294,11 @@ data AnswerReq = AnswerReq
   }
   deriving stock (Show, Eq)
 
-data AnswerResp = AnswerResp
+newtype AnswerResp = AnswerResp
   { arsAnswers :: [T.Text]
   }
   deriving stock (Show, Eq)
+  deriving newtype (IsList)
 
 $(deriveJSON (jsonOpts 2) ''OpenAIList)
 $(deriveJSON (jsonOpts 1) ''Engine)

--- a/openai-servant/src/OpenAI/Resources.hs
+++ b/openai-servant/src/OpenAI/Resources.hs
@@ -85,17 +85,7 @@ newtype OpenAIList a = OpenAIList
   { olData :: V.Vector a
   }
   deriving stock (Show, Eq, Functor)
-  deriving newtype (IsList)
-
-instance Semigroup (OpenAIList a) where
-  (<>) a b = OpenAIList (olData a <> olData b)
-
-instance Monoid (OpenAIList a) where
-  mempty = OpenAIList mempty
-
-instance Applicative OpenAIList where
-  pure = OpenAIList . pure
-  (<*>) go x = OpenAIList (olData go <*> olData x)
+  deriving newtype (Applicative, IsList, Monoid, Semigroup)
 
 newtype EngineId = EngineId {unEngineId :: T.Text}
   deriving stock (Eq, Show)

--- a/openai-servant/src/OpenAI/Resources.hs
+++ b/openai-servant/src/OpenAI/Resources.hs
@@ -52,6 +52,7 @@ where
 import qualified Data.Aeson as A
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Text as T
+import Data.String (IsString(..))
 import Data.Time
 import Data.Time.Clock.POSIX
 import qualified Data.Vector as V
@@ -95,7 +96,7 @@ instance Applicative OpenAIList where
 
 newtype EngineId = EngineId {unEngineId :: T.Text}
   deriving stock (Eq, Show)
-  deriving newtype (ToJSON, FromJSON, ToHttpApiData)
+  deriving newtype (IsString, ToJSON, FromJSON, ToHttpApiData)
 
 data Engine = Engine
   { eId :: EngineId,
@@ -106,7 +107,7 @@ data Engine = Engine
 
 newtype TextCompletionId = TextCompletionId {unTextCompletionId :: T.Text}
   deriving stock (Show, Eq)
-  deriving newtype (ToJSON, FromJSON, ToHttpApiData)
+  deriving newtype (IsString, ToJSON, FromJSON, ToHttpApiData)
 
 data TextCompletionChoice = TextCompletionChoice
   { tccText :: T.Text,
@@ -156,9 +157,10 @@ defaultTextCompletionCreate prompt =
       tccrBestOf = Nothing
     }
 
-data EmbeddingCreate = EmbeddingCreate
+newtype EmbeddingCreate = EmbeddingCreate
   {ecInput :: T.Text}
   deriving stock (Show, Eq)
+  deriving newtype (IsString)
 
 data Embedding = Embedding
   {eEmbedding :: V.Vector Double, eIndex :: Int}
@@ -166,7 +168,7 @@ data Embedding = Embedding
 
 newtype FineTuneId = FineTuneId {unFineTuneId :: T.Text}
   deriving stock (Show, Eq)
-  deriving newtype (ToJSON, FromJSON, ToHttpApiData)
+  deriving newtype (IsString, ToJSON, FromJSON, ToHttpApiData)
 
 data FineTuneCreate = FineTuneCreate
   { ftcTrainingFile :: FileId,
@@ -261,7 +263,7 @@ data FileCreate = FileCreate
 
 newtype FileId = FileId {unFileId :: T.Text}
   deriving stock (Show, Eq)
-  deriving newtype (ToJSON, FromJSON, ToHttpApiData)
+  deriving newtype (IsString, ToJSON, FromJSON, ToHttpApiData)
 
 data File = File
   { fId :: FileId,
@@ -271,10 +273,11 @@ data File = File
   }
   deriving stock (Show, Eq)
 
-data FileDeleteConfirmation = FileDeleteConfirmation
+newtype FileDeleteConfirmation = FileDeleteConfirmation
   { fdcId :: FileId
   }
   deriving stock (Show, Eq)
+  deriving newtype (IsString)
 
 data AnswerReq = AnswerReq
   { arFile :: Maybe FileId,

--- a/openai-servant/src/OpenAI/Resources.hs
+++ b/openai-servant/src/OpenAI/Resources.hs
@@ -84,12 +84,12 @@ instance ToHttpApiData TimeStamp where
 newtype OpenAIList a = OpenAIList
   { olData :: V.Vector a
   }
-  deriving stock (Show, Eq, Functor)
-  deriving newtype (Applicative, IsList, Monoid, Semigroup)
+  deriving stock (Eq, Functor)
+  deriving newtype (Applicative, IsList, Monoid, Semigroup, Show)
 
 newtype EngineId = EngineId {unEngineId :: T.Text}
-  deriving stock (Eq, Show)
-  deriving newtype (IsString, ToJSON, FromJSON, ToHttpApiData)
+  deriving stock (Eq)
+  deriving newtype (IsString, ToJSON, FromJSON, ToHttpApiData, Show)
 
 data Engine = Engine
   { eId :: EngineId,
@@ -99,8 +99,8 @@ data Engine = Engine
   deriving stock (Show, Eq)
 
 newtype TextCompletionId = TextCompletionId {unTextCompletionId :: T.Text}
-  deriving stock (Show, Eq)
-  deriving newtype (IsString, ToJSON, FromJSON, ToHttpApiData)
+  deriving stock (Eq)
+  deriving newtype (IsString, ToJSON, FromJSON, ToHttpApiData, Show)
 
 data TextCompletionChoice = TextCompletionChoice
   { tccText :: T.Text,
@@ -152,16 +152,16 @@ defaultTextCompletionCreate prompt =
 
 newtype EmbeddingCreate = EmbeddingCreate
   {ecInput :: T.Text}
-  deriving stock (Show, Eq)
-  deriving newtype (IsString)
+  deriving stock (Eq)
+  deriving newtype (IsString, Show)
 
 data Embedding = Embedding
   {eEmbedding :: V.Vector Double, eIndex :: Int}
   deriving stock (Show, Eq)
 
 newtype FineTuneId = FineTuneId {unFineTuneId :: T.Text}
-  deriving stock (Show, Eq)
-  deriving newtype (IsString, ToJSON, FromJSON, ToHttpApiData)
+  deriving stock (Eq)
+  deriving newtype (IsString, ToJSON, FromJSON, ToHttpApiData, Show)
 
 data FineTuneCreate = FineTuneCreate
   { ftcTrainingFile :: FileId,
@@ -255,8 +255,8 @@ data FileCreate = FileCreate
   deriving stock (Show, Eq)
 
 newtype FileId = FileId {unFileId :: T.Text}
-  deriving stock (Show, Eq)
-  deriving newtype (IsString, ToJSON, FromJSON, ToHttpApiData)
+  deriving stock (Eq)
+  deriving newtype (IsString, ToJSON, FromJSON, ToHttpApiData, Show)
 
 data File = File
   { fId :: FileId,
@@ -269,8 +269,8 @@ data File = File
 newtype FileDeleteConfirmation = FileDeleteConfirmation
   { fdcId :: FileId
   }
-  deriving stock (Show, Eq)
-  deriving newtype (IsString)
+  deriving stock (Eq)
+  deriving newtype (IsString, Show)
 
 data AnswerReq = AnswerReq
   { arFile :: Maybe FileId,
@@ -287,8 +287,8 @@ data AnswerReq = AnswerReq
 newtype AnswerResp = AnswerResp
   { arsAnswers :: [T.Text]
   }
-  deriving stock (Show, Eq)
-  deriving newtype (IsList)
+  deriving stock (Eq)
+  deriving newtype (IsList, Show)
 
 $(deriveJSON (jsonOpts 2) ''OpenAIList)
 $(deriveJSON (jsonOpts 1) ''Engine)

--- a/openai-servant/src/OpenAI/Resources.hs
+++ b/openai-servant/src/OpenAI/Resources.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -60,7 +61,7 @@ import Servant.Multipart.API
 
 -- | A 'UTCTime' wrapper that has unix timestamp JSON representation
 newtype TimeStamp = TimeStamp {unTimeStamp :: UTCTime}
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 instance A.ToJSON TimeStamp where
   toJSON = A.Number . fromRational . toRational . utcTimeToPOSIXSeconds . unTimeStamp
@@ -80,7 +81,7 @@ instance ToHttpApiData TimeStamp where
 newtype OpenAIList a = OpenAIList
   { olData :: V.Vector a
   }
-  deriving (Show, Eq, Functor)
+  deriving stock (Show, Eq, Functor)
 
 instance Semigroup (OpenAIList a) where
   (<>) a b = OpenAIList (olData a <> olData b)
@@ -93,17 +94,19 @@ instance Applicative OpenAIList where
   (<*>) go x = OpenAIList (olData go <*> olData x)
 
 newtype EngineId = EngineId {unEngineId :: T.Text}
-  deriving (Show, Eq, ToJSON, FromJSON, ToHttpApiData)
+  deriving stock (Eq, Show)
+  deriving newtype (ToJSON, FromJSON, ToHttpApiData)
 
 data Engine = Engine
   { eId :: EngineId,
     eOwner :: T.Text,
     eReady :: Bool
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 newtype TextCompletionId = TextCompletionId {unTextCompletionId :: T.Text}
-  deriving (Show, Eq, ToJSON, FromJSON, ToHttpApiData)
+  deriving stock (Show, Eq)
+  deriving newtype (ToJSON, FromJSON, ToHttpApiData)
 
 data TextCompletionChoice = TextCompletionChoice
   { tccText :: T.Text,
@@ -111,7 +114,7 @@ data TextCompletionChoice = TextCompletionChoice
     tccLogProps :: Maybe Int,
     tccFinishReason :: T.Text
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 data TextCompletion = TextCompletion
   { tcId :: TextCompletionId,
@@ -119,7 +122,7 @@ data TextCompletion = TextCompletion
     tcModel :: T.Text,
     tcChoices :: V.Vector TextCompletionChoice
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 data TextCompletionCreate = TextCompletionCreate
   { tccrPrompt :: T.Text, -- TODO: support lists of strings
@@ -134,7 +137,7 @@ data TextCompletionCreate = TextCompletionCreate
     tccrFrequencyPenalty :: Maybe Double,
     tccrBestOf :: Maybe Int
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 -- | Applies API defaults, only passing a prompt.
 defaultTextCompletionCreate :: T.Text -> TextCompletionCreate
@@ -155,14 +158,15 @@ defaultTextCompletionCreate prompt =
 
 data EmbeddingCreate = EmbeddingCreate
   {ecInput :: T.Text}
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 data Embedding = Embedding
   {eEmbedding :: V.Vector Double, eIndex :: Int}
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 newtype FineTuneId = FineTuneId {unFineTuneId :: T.Text}
-  deriving (Show, Eq, ToJSON, FromJSON, ToHttpApiData)
+  deriving stock (Show, Eq)
+  deriving newtype (ToJSON, FromJSON, ToHttpApiData)
 
 data FineTuneCreate = FineTuneCreate
   { ftcTrainingFile :: FileId,
@@ -176,7 +180,7 @@ data FineTuneCreate = FineTuneCreate
     ftcClassificationNClasses :: Maybe Int,
     ftcClassificationPositiveClass :: Maybe T.Text
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 defaultFineTuneCreate :: FileId -> FineTuneCreate
 defaultFineTuneCreate file =
@@ -198,7 +202,7 @@ data FineTuneEvent = FineTuneEvent
     fteLevel :: T.Text,
     fteMessage :: T.Text
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 data FineTune = FineTune
   { ftId :: FineTuneId,
@@ -208,14 +212,14 @@ data FineTune = FineTune
     ftTunedModel :: Maybe T.Text,
     ftStatus :: T.Text
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 data SearchResult = SearchResult
   { srDocument :: Int,
     srScore :: Double,
     srMetadata :: Maybe T.Text
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 data SearchResultCreate = SearchResultCreate
   { sccrFile :: Maybe FileId,
@@ -223,40 +227,41 @@ data SearchResultCreate = SearchResultCreate
     sccrQuery :: T.Text,
     sccrReturnMetadata :: Bool
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 data SearchHunk = SearchHunk
   { shText :: T.Text,
     shMetadata :: Maybe T.Text
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 data ClassificationHunk = ClassificationHunk
   { chText :: T.Text,
     chLabel :: T.Text
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 data FineTuneHunk = FineTuneHunk
   { fthPrompt :: T.Text,
     fthCompletion :: T.Text
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 data FileHunk
   = FhSearch SearchHunk
   | FhClassifications ClassificationHunk
   | FhFineTune FineTuneHunk
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 data FileCreate = FileCreate
   { fcPurpose :: T.Text,
     fcDocuments :: [FileHunk]
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 newtype FileId = FileId {unFileId :: T.Text}
-  deriving (Show, Eq, ToJSON, FromJSON, ToHttpApiData)
+  deriving stock (Show, Eq)
+  deriving newtype (ToJSON, FromJSON, ToHttpApiData)
 
 data File = File
   { fId :: FileId,
@@ -264,12 +269,12 @@ data File = File
     fStatus :: T.Text,
     fPurpose :: T.Text
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 data FileDeleteConfirmation = FileDeleteConfirmation
   { fdcId :: FileId
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 data AnswerReq = AnswerReq
   { arFile :: Maybe FileId,
@@ -281,12 +286,12 @@ data AnswerReq = AnswerReq
     arExamples :: [[T.Text]],
     arReturnMetadata :: Bool
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 data AnswerResp = AnswerResp
   { arsAnswers :: [T.Text]
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 $(deriveJSON (jsonOpts 2) ''OpenAIList)
 $(deriveJSON (jsonOpts 1) ''Engine)


### PR DESCRIPTION
The main semantic changes here are:

- Add `IsString` instances to types that support them

  This is the main thing I care about and the original motivation for this change.

- Add `IsList` instances to types that support them

- Update the matching `Show` instances

  … so that the displayed representation is more compact and still valid Haskell code (with `OverloadedStrings` and/or `OverloadedLists` enabled)

This also entailed enabling `DerivingStrategies`