### PR TITLE
Fix Audio APIs

### DIFF
--- a/openai-hs/src/OpenAI/Client.hs
+++ b/openai-hs/src/OpenAI/Client.hs
@@ -175,8 +175,20 @@ EP1 (createImageVariation, ImageVariationRequest, ImageResponse)
 
 EP1 (createEmbedding, EmbeddingCreate, EmbeddingResponse)
 
-EP1 (createTranscription, AudioTranscriptionRequest, AudioResponseData)
-EP1 (createAudioTranslation, AudioTranslationRequest, AudioResponseData)
+createTranscription :: OpenAIClient -> AudioTranscriptionRequest -> IO (Either ClientError AudioResponseData)
+createTranscription sc atr =
+  do
+    bnd <- MP.genBoundary
+    createTranscriptionInternal sc (bnd, atr)
+
+createAudioTranslation :: OpenAIClient -> AudioTranslationRequest -> IO (Either ClientError AudioResponseData)
+createAudioTranslation sc atr =
+  do
+    bnd <- MP.genBoundary
+    createAudioTranslationInternal sc (bnd, atr)
+
+EP1 (createTranscriptionInternal, (BSL.ByteString, AudioTranscriptionRequest), AudioResponseData)
+EP1 (createAudioTranslationInternal, (BSL.ByteString, AudioTranslationRequest), AudioResponseData)
 
 createFile :: OpenAIClient -> FileCreate -> IO (Either ClientError File)
 createFile sc rfc =
@@ -209,8 +221,8 @@ EP2 (engineCreateEmbedding, EngineId, EngineEmbeddingCreate, (OpenAIList EngineE
              :<|> createImageVariation'
            )
     :<|> (createEmbedding')
-    :<|> ( createTranscription'
-             :<|> createAudioTranslation'
+    :<|> ( createTranscriptionInternal'
+             :<|> createAudioTranslationInternal'
            )
     :<|> (createFileInternal' :<|> deleteFile')
     :<|> ( createFineTune'

--- a/openai-servant/openai-servant.cabal
+++ b/openai-servant/openai-servant.cabal
@@ -54,6 +54,7 @@ library
     , base >=4.7 && <5
     , bytestring
     , casing
+    , mime-types
     , servant
     , servant-multipart-api
     , text

--- a/openai-servant/package.yaml
+++ b/openai-servant/package.yaml
@@ -24,6 +24,7 @@ dependencies:
   - bytestring
   - time
   - vector
+  - mime-types
 
 ghc-options:
   - -Wall

--- a/openai-servant/src/OpenAI/Api.hs
+++ b/openai-servant/src/OpenAI/Api.hs
@@ -44,8 +44,8 @@ type EmbeddingsApi =
   OpenAIAuth :> ReqBody '[JSON] EmbeddingCreate :> Post '[JSON] EmbeddingResponse
 
 type AudioApi =
-  OpenAIAuth :> "transcriptions" :> ReqBody '[JSON] AudioTranscriptionRequest :> Post '[JSON] AudioResponseData
-    :<|> OpenAIAuth :> "translations" :> ReqBody '[JSON] AudioTranslationRequest :> Post '[JSON] AudioResponseData
+  OpenAIAuth :> "transcriptions" :> MultipartForm Tmp AudioTranscriptionRequest :> Post '[JSON] AudioResponseData
+    :<|> OpenAIAuth :> "translations" :> MultipartForm Tmp AudioTranslationRequest :> Post '[JSON] AudioResponseData
 
 type FilesApi =
   OpenAIAuth :> MultipartForm Mem FileCreate :> Post '[JSON] File


### PR DESCRIPTION
The Audio APIs require a multipart/form-data upload.
This changes the `audtsrFile` and `audtlrFile` fields to be of type FilePath.
