### PR TITLE
Support for function_call in Chat API

### DIFF
--- a/openai-hs/src/OpenAI/Client.hs
+++ b/openai-hs/src/OpenAI/Client.hs
@@ -27,6 +27,8 @@ module OpenAI.Client
     completeText,
 
     -- * Chat
+    ChatFunction (..),
+    ChatFunctionCall (..),
     ChatMessage (..),
     ChatCompletionRequest (..),
     ChatChoice (..),

--- a/openai-servant/src/OpenAI/Resources.hs
+++ b/openai-servant/src/OpenAI/Resources.hs
@@ -19,6 +19,8 @@ module OpenAI.Resources
     defaultCompletionCreate,
 
     -- * Chat
+    ChatFunction (..),
+    ChatFunctionCall (..),
     ChatMessage (..),
     ChatCompletionRequest (..),
     ChatChoice (..),

--- a/openai-servant/src/OpenAI/Resources.hs
+++ b/openai-servant/src/OpenAI/Resources.hs
@@ -238,9 +238,8 @@ data ChatFunctionCall = ChatFunctionCall
 instance A.FromJSON ChatFunctionCall where
   parseJSON = A.withObject "ChatFunctionCall" $ \obj -> do
     name <- obj A..: "name"
-    arguments <- obj A..: "arguments" >>=
-                 A.withText "Arguments"
-                 (either fail pure . A.eitherDecode . BSL.fromStrict . T.encodeUtf8)
+    arguments <- obj A..: "arguments" >>= A.withEmbeddedJSON "Arguments" pure
+                 
     pure $ ChatFunctionCall { chfcName = name, chfcArguments = arguments }
 
 instance A.ToJSON ChatFunctionCall where


### PR DESCRIPTION
Since aeson-schema is not current enough to support the JSON Schema
version used by OpenAI, use Aeson.Value to store function parameter
schema and function_call arguments.
