### PR TITLE
'content' must not be omitted

### DIFF
--- a/openai-hs/test/ApiSpec.hs
+++ b/openai-hs/test/ApiSpec.hs
@@ -72,6 +72,25 @@ apiTests2023 =
         res <- forceSuccess $ completeChat cli completion
         chrChoices res `shouldNotBe` []
         chmContent (chchMessage (head (chrChoices res))) `shouldBe` Just "down."
+      it "'content' is a required property" $ \cli -> do
+        let completion =
+              defaultChatCompletionRequest
+                (ModelId "gpt-3.5-turbo")
+                [ ChatMessage
+                    { chmRole = "assistant",
+                      chmContent = Nothing,
+                      chmFunctionCall = Just $ ChatFunctionCall { chfcName = "f", chfcArguments = "{}" },
+                      chmName = Nothing
+                    },
+                  ChatMessage
+                    { chmRole = "function",
+                      chmContent = Just "x",
+                      chmFunctionCall = Nothing,
+                      chmName = Just "f"
+                    }
+                ]
+        res <- forceSuccess $ completeChat cli completion
+        chrChoices res `shouldNotBe` []
 
     describe "edits api" $ do
       it "create edit" $ \cli -> do

--- a/openai-servant/src/OpenAI/Resources.hs
+++ b/openai-servant/src/OpenAI/Resources.hs
@@ -257,6 +257,23 @@ data ChatMessage = ChatMessage
   }
   deriving (Show, Eq)
 
+instance A.FromJSON ChatMessage where
+  parseJSON = A.withObject "ChatMessage" $ \obj ->
+    ChatMessage <$> obj A..:? "content"
+                <*> obj A..: "role"
+                <*> obj A..:? "function_call"
+                <*> obj A..:? "name"
+
+instance A.ToJSON ChatMessage where
+  toJSON (ChatMessage {chmContent = content, chmRole = role, chmFunctionCall = functionCall, chmName = name}) =
+    A.object $ 
+      [ "content" A..= content,
+        "role" A..= role
+      ] ++ catMaybes
+      [ ("function_call" A..=) <$> functionCall, 
+        ("name" A..=) <$> name
+      ]
+      
 data ChatFunction = ChatFunction
   { chfName :: T.Text,
     chfDescription :: T.Text,
@@ -314,7 +331,6 @@ data ChatResponse = ChatResponse
     chrUsage :: Usage
   }
 
-$(deriveJSON (jsonOpts 3) ''ChatMessage)
 $(deriveJSON (jsonOpts 3) ''ChatFunction)
 $(deriveJSON (jsonOpts 4) ''ChatCompletionRequest)
 $(deriveJSON (jsonOpts 4) ''ChatChoice)


### PR DESCRIPTION
Apparently, OpenAI rejects ChatMessage if content is omitted.
We need to set it to null explicity.

Sorry, this slipped my attention, probably warrants 0.3.0.1
