### PR TITLE
Support 'function_call' in 'ChatCompletionRequest'.

### DIFF
--- a/openai-hs/src/OpenAI/Client.hs
+++ b/openai-hs/src/OpenAI/Client.hs
@@ -29,6 +29,7 @@ module OpenAI.Client
     -- * Chat
     ChatFunction (..),
     ChatFunctionCall (..),
+    ChatFunctionCallStrategy (..),
     ChatMessage (..),
     ChatCompletionRequest (..),
     ChatChoice (..),


### PR DESCRIPTION
Fixes #17.

This PR adds a new field to `ChatCompletionRequest` to support the `function_call` as described in the [ChatGPT documentation](https://platform.openai.com/docs/api-reference/chat/create#function_call).

The name for the underlying type is a bit ad-hoc, but otoh it doesn't seem there is quite enough overlap with existing type to justify a generalisation. 