### PR TITLE
Add support for response_format

### DIFF
--- a/openai-hs/src/OpenAI/Client.hs
+++ b/openai-hs/src/OpenAI/Client.hs
@@ -35,6 +35,7 @@ module OpenAI.Client
     ChatCompletionRequest (..),
     ChatChoice (..),
     ChatResponse (..),
+    ResponseFormat(..),
     defaultChatCompletionRequest,
     completeChat,
 

--- a/openai-servant/src/OpenAI/Resources.hs
+++ b/openai-servant/src/OpenAI/Resources.hs
@@ -27,6 +27,7 @@ module OpenAI.Resources
     ChatCompletionRequest (..),
     ChatChoice (..),
     ChatResponse (..),
+    ResponseFormat(..),
     defaultChatCompletionRequest,
 
     -- * Edits
@@ -314,11 +315,33 @@ data ChatCompletionRequest = ChatCompletionRequest
     chcrStop :: Maybe (V.Vector T.Text),
     chcrMaxTokens :: Maybe Int,
     chcrPresencePenalty :: Maybe Double,
+    chcrResponseFormat :: Maybe ResponseFormat,
     chcrFrequencyPenalty :: Maybe Double,
     chcrLogitBias :: Maybe (V.Vector Double),
     chcrUser :: Maybe String
   }
   deriving (Show, Eq)
+
+data ResponseFormat
+  = RF_text
+  | RF_json_object
+  deriving (Show, Eq)
+
+instance ToJSON ResponseFormat where
+  toJSON = \case
+    RF_text        -> A.object [ "type" A..= A.String "text" ]
+    RF_json_object -> A.object [ "type" A..= A.String "json_object" ]
+
+instance FromJSON ResponseFormat where
+  parseJSON = A.withObject "ResponseFormat" $ \o -> do
+    rt <- o A..: "type"
+    case rt of
+      "text"
+        -> pure RF_text
+      "json_object"
+        -> pure RF_json_object
+      xs
+        -> fail $ "ResponseFormat unexpected type: " <> T.unpack xs
 
 defaultChatCompletionRequest :: ModelId -> [ChatMessage] -> ChatCompletionRequest
 defaultChatCompletionRequest model messages =
@@ -334,6 +357,7 @@ defaultChatCompletionRequest model messages =
       chcrStop = Nothing,
       chcrMaxTokens = Nothing,
       chcrPresencePenalty = Nothing,
+      chcrResponseFormat = Nothing,
       chcrFrequencyPenalty = Nothing,
       chcrLogitBias = Nothing,
       chcrUser = Nothing


### PR DESCRIPTION
Morning @agrafix 😉 

Recent versions of OpenAI added [JSON mode](https://platform.openai.com/docs/guides/text-generation/json-mode).

Passing a `response_format` [object](https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format) in a chat completion request ensures that OpenAI will try to respond with valid JSON.

I have extended a `ChatCompletionRequest` with this field which is optional anyway (as per documentation), so these changes are all backward compatibile.

Thanks!