### PR TITLE
Remove deprecated edits API

### DIFF
--- a/openai-hs/src/OpenAI/Client.hs
+++ b/openai-hs/src/OpenAI/Client.hs
@@ -38,13 +38,6 @@ module OpenAI.Client
     defaultChatCompletionRequest,
     completeChat,
 
-    -- * Edits
-    EditCreate (..),
-    EditChoice (..),
-    EditResponse (..),
-    createTextEdit,
-    defaultEditCreate,
-
     -- * Images
     ImageResponse (..),
     ImageResponseData (..),
@@ -183,8 +176,6 @@ EP1 (completeText, CompletionCreate, CompletionResponse)
 
 EP1 (completeChat, ChatCompletionRequest, ChatResponse)
 
-EP1 (createTextEdit, EditCreate, EditResponse)
-
 EP1 (generateImage, ImageCreate, ImageResponse)
 EP1 (createImageEdit, ImageEditRequest, ImageResponse)
 EP1 (createImageVariation, ImageVariationRequest, ImageResponse)
@@ -231,7 +222,6 @@ EP2 (engineCreateEmbedding, EngineId, EngineEmbeddingCreate, (OpenAIList EngineE
     )
     :<|> (completeText')
     :<|> (completeChat')
-    :<|> (createTextEdit')
     :<|> ( generateImage'
              :<|> createImageEdit'
              :<|> createImageVariation'

--- a/openai-hs/test/ApiSpec.hs
+++ b/openai-hs/test/ApiSpec.hs
@@ -92,16 +92,6 @@ apiTests2023 =
         res <- forceSuccess $ completeChat cli completion
         chrChoices res `shouldNotBe` []
 
-    describe "edits api" $ do
-      it "create edit" $ \cli -> do
-        let edit =
-              (defaultEditCreate (ModelId "text-davinci-edit-001") "Fox" "Pluralize the word")
-                { edcrN = Just 1
-                }
-        res <- forceSuccess $ createTextEdit cli edit
-        edrChoices res `shouldNotBe` []
-        edchText (head $ edrChoices res) `shouldBe` "Foxes\n"
-
     -- TODO (2023.03.22): Create tests for images, audio APIs
 
     describe "embeddings api" $ do

--- a/openai-servant/src/OpenAI/Api.hs
+++ b/openai-servant/src/OpenAI/Api.hs
@@ -16,7 +16,6 @@ type OpenAIApiInternal =
   "models" :> ModelsApi
     :<|> "completions" :> CompletionsApi
     :<|> "chat" :> ChatApi
-    :<|> "edits" :> EditsApi
     :<|> "images" :> ImagesApi
     :<|> "embeddings" :> EmbeddingsApi
     :<|> "audio" :> AudioApi
@@ -33,9 +32,6 @@ type CompletionsApi =
 
 type ChatApi =
   OpenAIAuth :> "completions" :> ReqBody '[JSON] ChatCompletionRequest :> Post '[JSON] ChatResponse
-
-type EditsApi =
-  OpenAIAuth :> ReqBody '[JSON] EditCreate :> Post '[JSON] EditResponse
 
 type ImagesApi =
   OpenAIAuth :> "generations" :> ReqBody '[JSON] ImageCreate :> Post '[JSON] ImageResponse

--- a/openai-servant/src/OpenAI/Resources.hs
+++ b/openai-servant/src/OpenAI/Resources.hs
@@ -29,12 +29,6 @@ module OpenAI.Resources
     ChatResponse (..),
     defaultChatCompletionRequest,
 
-    -- * Edits
-    EditCreate (..),
-    EditChoice (..),
-    EditResponse (..),
-    defaultEditCreate,
-
     -- * Images
     ImageResponse (..),
     ImageResponseData (..),
@@ -358,49 +352,6 @@ $(deriveJSON (jsonOpts 3) ''ChatFunction)
 $(deriveJSON (jsonOpts 4) ''ChatCompletionRequest)
 $(deriveJSON (jsonOpts 4) ''ChatChoice)
 $(deriveJSON (jsonOpts 3) ''ChatResponse)
-
-------------------------
------- Edits API
-------------------------
-
-data EditCreate = EditCreate
-  { edcrModel :: ModelId,
-    edcrInput :: Maybe T.Text,
-    edcrInstruction :: T.Text,
-    edcrN :: Maybe Int,
-    edcrTemperature :: Maybe Double,
-    edcrTopP :: Maybe Double
-  }
-  deriving (Show, Eq)
-
-defaultEditCreate :: ModelId -> T.Text -> T.Text -> EditCreate
-defaultEditCreate model input instruction =
-  EditCreate
-    { edcrModel = model,
-      edcrInput = Just input,
-      edcrInstruction = instruction,
-      edcrN = Nothing,
-      edcrTemperature = Nothing,
-      edcrTopP = Nothing
-    }
-
-data EditChoice = EditChoice
-  { edchText :: T.Text,
-    edchIndex :: Int
-  }
-  deriving (Show, Eq)
-
-data EditResponse = EditResponse
-  { edrObject :: T.Text,
-    edrCreated :: Int,
-    edrChoices :: [EditChoice],
-    edrUsage :: Usage
-  }
-  deriving (Show, Eq)
-
-$(deriveJSON (jsonOpts 4) ''EditCreate)
-$(deriveJSON (jsonOpts 4) ''EditChoice)
-$(deriveJSON (jsonOpts 3) ''EditResponse)
 
 ------------------------
 ------ Images API


### PR DESCRIPTION
You should use the chat completions API instead according to OpenAI https://platform.openai.com/docs/deprecations/edit-models-endpoint