### PR TITLE
Add seed to ChatCompletionRequest

### DIFF
--- a/openai-hs/README.md
+++ b/openai-hs/README.md
@@ -34,13 +34,16 @@ request = ChatCompletionRequest
                          }
             ]
          , chcrFunctions = Nothing
+         , chcrFunctionCall = Nothing
          , chcrTemperature = Nothing
          , chcrTopP = Nothing
          , chcrN = Nothing
+         , chcrSeed = Nothing
          , chcrStream = Nothing
          , chcrStop = Nothing
          , chcrMaxTokens = Nothing
          , chcrPresencePenalty = Nothing
+         , chcrResponseFormat = Nothing
          , chcrFrequencyPenalty = Nothing
          , chcrLogitBias = Nothing
          , chcrUser = Nothing

--- a/openai-servant/src/OpenAI/Resources.hs
+++ b/openai-servant/src/OpenAI/Resources.hs
@@ -156,7 +156,7 @@ newtype ModelId = ModelId {unModelId :: T.Text}
 $(deriveJSON (jsonOpts 1) ''Model)
 
 ------------------------
------- Completions API
+------ Completions API (legacy)
 ------------------------
 
 data CompletionCreate = CompletionCreate
@@ -305,6 +305,7 @@ data ChatCompletionRequest = ChatCompletionRequest
     chcrTemperature :: Maybe Double,
     chcrTopP :: Maybe Double,
     chcrN :: Maybe Int,
+    chcrSeed :: Maybe Int,
     chcrStream :: Maybe Bool,
     chcrStop :: Maybe (V.Vector T.Text),
     chcrMaxTokens :: Maybe Int,
@@ -347,6 +348,7 @@ defaultChatCompletionRequest model messages =
       chcrTemperature = Nothing,
       chcrTopP = Nothing,
       chcrN = Nothing,
+      chcrSeed = Nothing,
       chcrStream = Nothing,
       chcrStop = Nothing,
       chcrMaxTokens = Nothing,


### PR DESCRIPTION
Add these field that are also usable by Ollama; tested locally.

@nickhs I overlooked that there already two similar PRs xD. It seems to be an important issue for some. It would be great to have this as it helps for integrating Ollama/Openai into apps. Feel free to modify this PR, request changes etc.