### PR TITLE
Adds support for DALL-E 3

### DIFF
--- a/openai-hs/src/OpenAI/Client.hs
+++ b/openai-hs/src/OpenAI/Client.hs
@@ -42,6 +42,7 @@ module OpenAI.Client
     -- * Images
     ImageResponse (..),
     ImageResponseData (..),
+    ImageResponseFormat (..),
     ImageCreate (..),
     ImageEditRequest (..),
     ImageVariationRequest (..),


### PR DESCRIPTION
This adds the ability to pass different models to `ImageCreate` and the ability for `ImageResponseData` to handle base64 encoded json in addition to URLs in `ImageResponseData`.