### PR TITLE
Fix cpphs usage

### DIFF
--- a/openai-hs/src/OpenAI/Client.hs
+++ b/openai-hs/src/OpenAI/Client.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-{-# OPTIONS_GHC -cpp -pgmPcpphs -optP--cpp #-}
+{-# OPTIONS_GHC -cpp -pgmP "cpphs --cpp" #-}
 
 module OpenAI.Client
   ( -- * Basics


### PR DESCRIPTION
When trying to build `openai-hs` (GHC 8.10.7), I got an error related to CPP. [This GHC issue comment](https://gitlab.haskell.org/ghc/ghc/-/issues/16737#note_225454) describes the error and the fix.